### PR TITLE
Fix PHP 7.2 compatibility.

### DIFF
--- a/src/Queue/SqsSnsQueue.php
+++ b/src/Queue/SqsSnsQueue.php
@@ -45,7 +45,7 @@ class SqsSnsQueue extends SqsQueue
             'AttributeNames' => ['ApproximateReceiveCount'],
         ]);
 
-        if (count($response['Messages']) > 0) {
+        if (is_array($response['Messages']) && count($response['Messages']) > 0) {
             return new SqsSnsJob(
                 $this->container,
                 $this->sqs,


### PR DESCRIPTION
Fixed an error that occurs when $response ['Messages'] is not countable in PHP 7.2.
